### PR TITLE
fix(todo): ensure collaborators render after page reload

### DIFF
--- a/apps/todo/src/components/ProjectBar.vue
+++ b/apps/todo/src/components/ProjectBar.vue
@@ -11,11 +11,9 @@
   import { useCurrentUser } from '../composables/useCurrentUser';
   import { useCollaborators } from '../composables/useCollaborators';
   import ManageCollaboratorsDialog from './ManageCollaboratorsDialog.vue';
-  import { useRoute } from 'vue-router';
   import ProjectSelect from './ProjectSelect.vue';
   import { cn } from '@cockpit-app/shared-utils';
 
-  const route = useRoute();
   const { selectedProject } = useProjects();
   const { currentUser } = useCurrentUser();
   const { isCurrentUserOwner, collaborators, fetchCollaborators } =
@@ -41,12 +39,13 @@
   }
 
   watch(
-    () => route.query['project'],
+    selectedProject,
     (newProject) => {
-      if (newProject) {
+      if (newProject && !newProject.is_general) {
         fetchCollaborators();
       }
     },
+    { immediate: true }
   );
 </script>
 <template>


### PR DESCRIPTION
## Summary
Fixes collaborators not displaying in the project bar after page reload.

## Changes
- Changed the watcher in `ProjectBar.vue` to watch `selectedProject` instead of route query
- Added `immediate: true` to ensure collaborators are fetched on component mount
- Removed unused `useRoute` dependency
- Added condition to only fetch collaborators for non-general projects

## Root Cause
The previous implementation only fetched collaborators when the route query parameter changed, but not during initial component mount after page reload. This left collaborators in an empty state until the user navigated to a different project and back.

## Solution
By watching the `selectedProject` directly with `immediate: true`, collaborators are now fetched whenever:
1. The component mounts (page reload scenario)
2. The user switches projects
3. The selected project changes for any reason

## Testing
- ✅ Collaborators now display correctly after page reload
- ✅ Collaborators still update when switching projects
- ✅ No unnecessary API calls for general/inbox projects

Fixes #10