### PR TITLE
feat(todo): Add inbox grouping by project/category with visual separators

### DIFF
--- a/apps/todo/src/components/TodoItem.vue
+++ b/apps/todo/src/components/TodoItem.vue
@@ -83,11 +83,8 @@
         @click.stop
       />
       <label class="flex flex-1 cursor-pointer flex-col pl-1">
-        <span :class="cn('pt-1', item.is_closed ? 'line-through' : '')">
+        <span :class="cn(item.is_closed ? 'line-through' : '')">
           {{ item.name }}
-        </span>
-        <span class="pr-2 text-xs text-gray-500">
-          {{ item.project?.name || ALL_PROJECT_NAME }}
         </span>
       </label>
       <Button

--- a/apps/todo/src/components/TodoList.vue
+++ b/apps/todo/src/components/TodoList.vue
@@ -21,13 +21,55 @@
     }
     return todoItems.value;
   });
+
+  const groupedTodoItems = computed(() => {
+    const items = projectTodoItems.value;
+    const groups = new Map<
+      string,
+      { projectName: string; items: typeof items }
+    >();
+
+    items.forEach((item) => {
+      const projectName = item.project?.name || 'No Project';
+      const key = item.project_id?.toString() || 'no-project';
+
+      if (!groups.has(key)) {
+        groups.set(key, { projectName, items: [] });
+      }
+      groups.get(key)!.items.push(item);
+    });
+
+    return Array.from(groups.values()).sort((a, b) =>
+      a.projectName.localeCompare(b.projectName),
+    );
+  });
 </script>
 
 <template>
-  <ul class="py-8">
-    <template v-for="(item, idx) in projectTodoItems" :key="item.id">
-      <TodoItem :item="item" />
-      <Divider v-if="idx < projectTodoItems.length - 1" class="my-2" />
+  <div class="py-8">
+    <template
+      v-for="(group, groupIdx) in groupedTodoItems"
+      :key="`group-${groupIdx}`"
+    >
+      <div class="mb-6">
+        <div class="mb-3">
+          <h3
+            class="px-1 text-base font-semibold text-gray-800 sm:px-0 sm:text-lg dark:text-gray-200"
+          >
+            {{ group.projectName }}
+          </h3>
+          <div class="mt-2">
+            <Divider />
+          </div>
+        </div>
+
+        <ul>
+          <template v-for="(item, itemIdx) in group.items" :key="item.id">
+            <TodoItem :item="item" />
+            <Divider v-if="itemIdx < group.items.length - 1" class="my-2" />
+          </template>
+        </ul>
+      </div>
     </template>
-  </ul>
+  </div>
 </template>


### PR DESCRIPTION
## Summary

Implements inbox grouping by project/category with visual separators to improve todo organization and readability.

## Changes Made

### TodoList.vue
- Added `groupedTodoItems` computed property that groups todos by project
- Groups are sorted alphabetically by project name
- Updated template to render grouped structure with project headers
- Added visual separators (dividers) between project titles and todo items

### TodoItem.vue
- Removed individual project name display from todo items since they're now grouped
- Simplified the todo item layout by removing redundant project information
- Maintained all existing functionality for todo item interactions

## Features Implemented

✅ **Inbox Grouping**: Todo items are now grouped by their project/category
✅ **Project Headers**: Each group displays the project name prominently at the top
✅ **Visual Separation**: Clear dividers separate project titles from todo items
✅ **Alphabetical Sorting**: Project groups are sorted alphabetically for consistency
✅ **Clean Hierarchy**: Visual distinction between different project groups
✅ **Responsive Design**: Works seamlessly on mobile devices
✅ **Preserved Functionality**: All existing todo item functionality maintained within groups

## Technical Details

- Uses Vue 3 Composition API with computed properties for efficient reactivity
- Groups are created using a Map for optimal performance
- No-project todos are handled gracefully with a "No Project" label
- Maintains existing styling patterns and TailwindCSS classes
- Preserves PrimeVue Divider component usage for consistency

## Testing

- [x] Verified grouping works correctly with multiple projects
- [x] Confirmed "No Project" handling for todos without assigned projects
- [x] Tested responsive behavior on mobile devices
- [x] Validated existing todo operations (check/uncheck, delete) still work

Closes #13